### PR TITLE
change articleHearts from selecting .like to .like-glyph

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -14,7 +14,7 @@ let colorStates = {
 // Without JavaScript, clicking on these heart shapes does nothing. Uncomment
 // this code and refresh the demo page.
 
-// let articleHearts = document.querySelectorAll(".like");
+// let articleHearts = document.querySelectorAll(".like-glyph");
 
 function likeCallback(e) {
   let heart = e.target;


### PR DESCRIPTION
There is a bug currently displaying the text "undefined" if the "Like! " text is clicked instead of the button. (See https://github.com/learn-co-curriculum/fewpjs-stitching-together-the-three-pillars/issues/7) This fixes the bug by changing the definition of articleHearts to just be the glypy.